### PR TITLE
Update the Intrinsic and Intervention Runner Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pip install -r requirements.txt
 
 The `monitor_progress.py` script can also be used to retrieve and print progress of your work package.
 
+### Intrinsic Hosting Capacity
+
+Use `run_intrinsic_work_package.py ./config` to find how much load or generation the network can support before hitting a voltage or thermal limit, rather than testing a specific DER scenario. `run_hv_node_headroom_work_package.py ./config` is the HV counterpart, testing HV nodes one at a time.
+
 ### Interventions
 
 Use `run_intervention_work_package.py ./config` to run an Intervention work package against a prior (base) work package. Set `INTERVENTION_TYPE` near the top of the script to choose which intervention to run (COMMUNITY_BESS, LV_STATCOMS, DISTRIBUTION_TAP_OPTIMIZATION, DISTRIBUTION_TX_OLTC, TARIFF_REFORM, CONTROLLED_LOAD_HOT_WATER, DVMS, or PHASE_REBALANCING) and `BASE_WORK_PACKAGE_ID` to point at the base work package's ID, then edit the relevant `build_..._intervention()` function for that type's parameters.

--- a/run_forecast_work_package.py
+++ b/run_forecast_work_package.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from zepben.eas import ForecastConfigInput, TimePeriodInput, Mutation, WorkPackageInput, HcGeneratorConfigInput, \
     HcModelConfigInput, HcFeederScenarioAllocationStrategy, HcSolveConfigInput, \
     HcResultProcessorConfigInput, HcWriterConfigInput, HcWriterOutputConfigInput, HcEnhancedMetricsConfigInput, \
-    HcStoredResultsConfigInput, HcMetricsResultsConfigInput
+    HcStoredResultsConfigInput, HcMetricsResultsConfigInput, HcWriterType
 
 from utils import get_client, get_config, print_run, get_config_dir
 
@@ -50,14 +50,14 @@ async def main(argv):
                         pFactorBaseImports=1,
                         pFactorForecastPv=1,
                         # fixSinglePhaseLoads defaults to true - set False here to disable the single-phase load fixer.
-                        fixSinglePhaseLoads=False,
-                        maxSinglePhaseLoad=15000.0,
-                        maxLoadServiceLineRatio=1.5,
+                        fixSinglePhaseLoads=True,
+                        fixOverloadingConsumers=True,
+                        fixUndersizedServiceLines=True,
+                        maxSinglePhaseLoad=20000.0,
+                        maxLoadServiceLineRatio=2.0,
                         maxLoadLvLineRatio=2.0,
                         maxLoadTxRatio=3.0,
                         maxGenTxRatio=10.0,
-                        fixOverloadingConsumers=True,
-                        fixUndersizedServiceLines=True,
                         feederScenarioAllocationStrategy=HcFeederScenarioAllocationStrategy.ADDITIVE,
                         # closedLoopVRegEnabled defaults to true. Set False to model regulators as-is from the network model.
                         closedLoopVRegEnabled=False,
@@ -67,7 +67,9 @@ async def main(argv):
                 ),
 
                 resultProcessorConfig=HcResultProcessorConfigInput(
+                    # writerType=POSTGRES writes results to Postgres (vs. PARQUET files). Check with your administrator which is supported for your environment.
                     writerConfig=HcWriterConfigInput(
+                        writerType=HcWriterType.POSTGRES,
                         outputWriterConfig=HcWriterOutputConfigInput(
                             enhancedMetricsConfig=HcEnhancedMetricsConfigInput(
                                 populateEnhancedMetrics=True,
@@ -88,8 +90,6 @@ async def main(argv):
                         energyMetersRaw=False,
                         energyMeterVoltagesRaw=False
                     ),
-                    # calculatePerformanceMetrics is deprecated - prefer populateEnhancedMetrics above.
-                    metrics=HcMetricsResultsConfigInput(calculatePerformanceMetrics=False)
                 ),
                 qualityAssuranceProcessing=False
             ),

--- a/run_hv_node_headroom_work_package.py
+++ b/run_hv_node_headroom_work_package.py
@@ -1,23 +1,22 @@
 """
-Example: run an Intrinsic Hosting Capacity work package.
+Example: run an HV Node Headroom work package.
 
-Finds how much load/generation the network can support before hitting a voltage/thermal limit,
-instead of testing a specific DER scenario. Full field reference: HCM docs, "How to run a
-Hosting Capacity Work Package".
+HV counterpart to LV intrinsic: tests HV nodes one at a time to find headroom before a
+voltage/thermal limit. Run time scales with node count. Full field reference: HCM docs,
+"How to run an HV Node Headroom Work Package".
 """
 
 import asyncio
 import sys
 from datetime import datetime
-from zepben.eas import Mutation, IntrinsicWorkPackageInput, IntrinsicSyfConfigInput, \
-    IntrinsicSearchConfigInput, IntrinsicInitialLoadStateConfigInput, \
-    IntrinsicInitialStateSelectorMode, IntrinsicConstraintsConfigInput, \
-    IntrinsicVoltageConstraintsInput, IntrinsicLvVoltageConstraintInput, IntrinsicHvVoltageConstraintInput, \
-    IntrinsicThermalConstraintsInput, IntrinsicThermalConstraintInput, IntrinsicRatingBasis, \
-    IntrinsicInjectionResourceConfigInput, IntrinsicInjectionResourceMethod, IntrinsicLoadModelType, \
-    IntrinsicPhaseMatching, IntrinsicAllocationConfigInput, IntrinsicAllocationMethod, \
-    IntrinsicAllocationScope, IntrinsicExistingCapacityBasis, IntrinsicCapacityGroupPlacementType, \
-    IntrinsicWriterConfigInput, HcWriterType, HcModelConfigInput, HcSolveConfigInput
+from zepben.eas import Mutation, HvNodeHeadroomWorkPackageInput, IntrinsicSyfConfigInput, \
+    IntrinsicInitialLoadStateConfigInput, IntrinsicInitialStateSelectorMode, \
+    IntrinsicConstraintsConfigInput, IntrinsicVoltageConstraintsInput, IntrinsicLvVoltageConstraintInput, \
+    IntrinsicHvVoltageConstraintInput, IntrinsicThermalConstraintsInput, IntrinsicThermalConstraintInput, \
+    IntrinsicRatingBasis, IntrinsicInjectionResourceConfigInput, IntrinsicInjectionResourceMethod, \
+    IntrinsicLoadModelType, IntrinsicPhaseMatching, IntrinsicWriterConfigInput, HcWriterType, \
+    HcModelConfigInput, HcSolveConfigInput, \
+    HvNodeHeadroomSearchConfigInput, HvNodeLocationSelectorInput, HvNodeLocationKind
 
 from utils import get_client, get_config, print_run, get_config_dir
 
@@ -28,15 +27,14 @@ async def main(argv):
     eas_client = get_client(config_dir)
 
     try:
-        result = await eas_client.mutation(Mutation.run_intrinsic_work_package(
-            IntrinsicWorkPackageInput(
+        result = await eas_client.mutation(Mutation.run_hv_node_headroom_work_package(
+            HvNodeHeadroomWorkPackageInput(
                 syf=IntrinsicSyfConfigInput(
                     feeders=config["feeders"],
                     scenario="base",  # or a different scenario if desired
                     year=config["forecast_years"][0]
                 ),
-                # Baseline before generation is added - see docs "Choosing the Initial State" for
-                # mode comparison.
+                # Baseline before generation is added - see docs "Choosing the Initial State" for mode comparison.
                 initialStateSelector=IntrinsicInitialLoadStateConfigInput(
                     selectorMode=IntrinsicInitialStateSelectorMode.ZERO_LOAD,
                     # Naive datetimes are interpreted in the server's timezone, not yours.
@@ -47,19 +45,27 @@ async def main(argv):
                     # perCustomerLoadWatts=500.0, perCustomerGenWatts=0.0,   # FIXED_LOAD only, required
                     # perCustomerLoadVar=0.0, perCustomerGenVar=0.0,         # FIXED_LOAD only, required
                 ),
+                # HV node types to test. Default (selector omitted) is DTX_HV_TERMINAL only.
+                nodeLocationSelector=HvNodeLocationSelectorInput(
+                    locationKinds=[
+                        HvNodeLocationKind.DTX_HV_TERMINAL,
+                        HvNodeLocationKind.SWITCH_UPSTREAM_TERMINAL,
+                        HvNodeLocationKind.LINE_TEE,
+                    ]
+                ),
                 # LV voltage limits, volts phase-to-neutral. Adjust to your network standard.
                 # A supplied hv=/thermal= block enables that constraint - see docs "Constraints Config".
                 constraints=IntrinsicConstraintsConfigInput(
                     voltage=IntrinsicVoltageConstraintsInput(
                         lv=IntrinsicLvVoltageConstraintInput(max=260, min=207),
-                        hv=IntrinsicHvVoltageConstraintInput(minPu=0.90, maxPu=1.10),
+                        hv=IntrinsicHvVoltageConstraintInput(minPu=0.90, maxPu=1.1),
                     ),
                     thermal=IntrinsicThermalConstraintsInput(
                         lv=IntrinsicThermalConstraintInput(percentOfRating=100.0, ratingBasis=IntrinsicRatingBasis.NORMAL),
                         hv=IntrinsicThermalConstraintInput(percentOfRating=100.0, ratingBasis=IntrinsicRatingBasis.NORMAL),
                     ),
                 ),
-                # EXPORT_GENERATION: solar/gen headroom. IMPORT_LOAD: import headroom (EV/load growth).
+                # EXPORT_GENERATION: solar/gen headroom per node. IMPORT_LOAD: import headroom (EV/load growth).
                 injectionResource=IntrinsicInjectionResourceConfigInput(
                     method=IntrinsicInjectionResourceMethod.EXPORT_GENERATION,
                     loadModelType=IntrinsicLoadModelType.NEGATIVE_LOAD,
@@ -67,13 +73,11 @@ async def main(argv):
                     # phaseMatching=...,  # only MATCH_CUSTOMER_PHASES exposed currently
                     # pvProfileId="some-pv-profile-id",  # required when loadModelType is PV_SYSTEM
                 ),
-                # headroom == stepKwPerCustomer * maxSteps means search hit the cap, not a real
-                # constraint - raise maxSteps (<=10000) or step size.
-                search=IntrinsicSearchConfigInput(
-                    stepKwPerCustomer=1.0,
-                    maxSteps=200,
-                    lockOutCapacityZoneOnViolation=True,
-                    stopOnHvViolation=True
+                # headroom == stepKwPerNode * maxStepsPerNode means search hit the cap, not a
+                # real constraint - raise maxStepsPerNode (<=1000) or step size.
+                search=HvNodeHeadroomSearchConfigInput(
+                    stepKwPerNode=10.0,
+                    maxStepsPerNode=200,
                 ),
                 # PARQUET writes result files, POSTGRES writes to the results database - check which your environment supports.
                 resultsWriter=IntrinsicWriterConfigInput(

--- a/run_intervention_work_package.py
+++ b/run_intervention_work_package.py
@@ -1,19 +1,15 @@
 """
-This script provides an example of how to run an Intervention work package.
+Example: run a stacked Intervention work package.
 
-An intervention work package is a normal forecast work package with an additional `intervention`
-block set, pointing `baseWorkPackageId` at a prior work package. That base work
-package must have been run with: EnhancedMetrics=True, distTransformers=True,
-ScenarioAllocationStrategy=ADDITIVE, and either a single year, or a contiguous range of years
+A normal forecast work package with an `intervention` block set. The block combines up to one
+candidate intervention with any of phaseRebalanceProportions, dvms and loadReshaping, all applied
+to the same network. See HCS docs, "How to run an Intervention Work Package" for the base work
+package prerequisites, "Interventions Options" for per-type parameters, and "Interventions
+Concepts" for stacking vs chaining.
 
-See the "How to run an Intervention Work Package" guide in the HCS documentation for details
+Remember to update the standard model config arguments at the bottom to match your parent work package.
 
-Set INTERVENTION_TYPE below to choose which intervention to run. 
-
-Note: `specificAllocationInstance` (single instance name) is used below for COMMUNITY_BESS,
-LV_STATCOMS, and DISTRIBUTION_TX_OLTC. An upcoming release replaces this with
-`allocationInstanceSelection` (a list of instance names), which will let COMMUNITY_BESS size
-across multiple candidate instances instead of just one. Update these examples once that ships.
+Requires zepben.eas 2.18.0b1+.
 """
 
 import asyncio
@@ -23,138 +19,138 @@ from zepben.eas import ForecastConfigInput, TimePeriodInput, Mutation, WorkPacka
     HcModelConfigInput, HcFeederScenarioAllocationStrategy, HcSolveConfigInput, HcMeterPlacementConfigInput, \
     HcResultProcessorConfigInput, HcWriterConfigInput, HcWriterOutputConfigInput, HcEnhancedMetricsConfigInput, \
     HcStoredResultsConfigInput, HcMetricsResultsConfigInput, \
-    InterventionConfigInput, InterventionClass, YearRangeInput, DvmsConfigInput, DvmsRegulatorConfigInput, \
-    PhaseRebalanceProportionsInput, CandidateGenerationConfigInput, CandidateGenerationType
+    InterventionConfigInput, CandidateInterventionConfigInput, CandidateInterventionClass, \
+    YearRangeInput, DvmsConfigInput, DvmsRegulatorConfigInput, PhaseRebalanceProportionsInput, \
+    LoadReshapingConfigInput, CandidateGenerationConfigInput, CandidateGenerationType
 from utils import get_client, get_config, print_run, get_config_dir
 
-# Choose which intervention to run.
-INTERVENTION_TYPE = InterventionClass.COMMUNITY_BESS
+# The parent (previously called base) work package to compare against.
+PARENT_WORK_PACKAGE_ID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
-# Work package ID of the base (non-intervention) work package to compare against.
-BASE_WORK_PACKAGE_ID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# Optional - if omitted, defaults to the work package's full year range.
+YEAR_RANGE = YearRangeInput(minYear=1, maxYear=9999)
 
-# Year range for the intervention. Must be a single year or a contiguous range, and should match the base work package's years.
-YEAR_RANGE = YearRangeInput(minYear=2026, maxYear=2030)
+# --- Choose what to run -------------------------------------------------------------------------
+# One candidate intervention, plus any combination of the three non-candidate ones.
 
-# COMMUNITY_BESS
-def build_community_bess_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
+# Set to None to run with no candidate intervention.
+CANDIDATE_INTERVENTION = CandidateInterventionClass.COMMUNITY_BESS
+
+ENABLE_LOAD_RESHAPING = True  # Previously called TARIFF_REFORM and CONTROLLED_LOAD_HOT_WATER
+ENABLE_PHASE_REBALANCING = True
+ENABLE_DVMS = False  # Runs at every time step (computationally expensive)
+
+
+# --- Candidate interventions: pick AT MOST 1 --------------------------------------------------
+
+def build_community_bess_candidate() -> CandidateInterventionConfigInput:
+    return CandidateInterventionConfigInput(
+        interventionType=CandidateInterventionClass.COMMUNITY_BESS,
         yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.COMMUNITY_BESS,
-        allocationLimitPerYear=20,  # Maximum number of batteries to install per year
+        allocationLimitPerYear=999,
         candidateGeneration=CandidateGenerationConfigInput(
-            type=CandidateGenerationType.CRITERIA,  # Required for COMMUNITY_BESS
-            interventionCriteriaName="bess-intervention-criteria-gen-thermal",  # References intervention_candidate_criteria.name
+            type=CandidateGenerationType.CRITERIA,
+            interventionCriteriaName="<your-candidate-criteria>",  # intervention_candidate_criteria.name
+            sizingLookaheadYears=3,
         ),
-        allocationCriteria="bess_allocation_criteria",  # References bess_allocation_criteria.name
-        specificAllocationInstance="EcoSTORE",  # Optional; omit to consider all instances in bess_instances
-        sizingLookaheadYears=3,  # Optional, defaults to 1
+        candidateAllocationCriteria="<your-allocation-criteria>",  # bess_allocation_criteria.name
+        allocationInstanceSelection=["<your-bess-instance>"],  # bess_instances.name; omit to size across all
     )
 
-# LV_STATCOMS
-def build_lv_statcoms_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
+
+def build_lv_statcoms_candidate() -> CandidateInterventionConfigInput:
+    return CandidateInterventionConfigInput(
+        interventionType=CandidateInterventionClass.LV_STATCOMS,
         yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.LV_STATCOMS,
-        allocationLimitPerYear=20,  # Maximum number of LV STATCOMs to install per year
+        allocationLimitPerYear=999,
         candidateGeneration=CandidateGenerationConfigInput(
-            type=CandidateGenerationType.CRITERIA,  # Required for LV_STATCOMS
-            interventionCriteriaName="lvstatcom-intervention-criteria",  # References intervention_candidate_criteria.name
+            type=CandidateGenerationType.CRITERIA,
+            interventionCriteriaName="<your-candidate-criteria>",  # intervention_candidate_criteria.name
         ),
-        allocationCriteria="lv_statcom_allocation_criteria_2",  # References lv_statcom_allocation_criteria.name
-        specificAllocationInstance="lv_statcom_instance_1",  # Optional; if omitted, first matching instance is used
+        candidateAllocationCriteria="<your-allocation-criteria>",  # lv_statcom_allocation_criteria.name
+        allocationInstanceSelection=["<your-statcom-instance>"],  # lv_statcom_instances.name
     )
 
-# DISTRIBUTION_TAP_OPTIMIZATION
-def build_distribution_tap_optimization_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
+
+def build_distribution_tap_optimization_candidate() -> CandidateInterventionConfigInput:
+    return CandidateInterventionConfigInput(
+        interventionType=CandidateInterventionClass.DISTRIBUTION_TAP_OPTIMIZATION,
         yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.DISTRIBUTION_TAP_OPTIMIZATION,
-        allocationLimitPerYear=30,  # Optional; omit for unlimited transformers per year
+        allocationLimitPerYear=999,
         candidateGeneration=CandidateGenerationConfigInput(
-            type=CandidateGenerationType.TAP_OPTIMIZATION,  # Required for DISTRIBUTION_TAP_OPTIMIZATION
-            # Voltage thresholds, applied per measurement zone per year
+            type=CandidateGenerationType.TAP_OPTIMIZATION,
             averageVoltageSpreadThreshold=40,
             voltageUnderLimitHoursThreshold=48,
             voltageOverLimitHoursThreshold=48,
-            # Tap weighting thresholds (direction arbitration); defaults (-10.0, 10.0) suit most cases
             tapWeightingFactorLowerThreshold=-10.0,
             tapWeightingFactorUpperThreshold=10.0,
         ),
+        # This type allocates directly from candidateGeneration - no candidateAllocationCriteria.
     )
 
-# DISTRIBUTION_TX_OLTC
-def build_distribution_tx_oltc_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
+
+def build_distribution_tx_oltc_candidate() -> CandidateInterventionConfigInput:
+    return CandidateInterventionConfigInput(
+        interventionType=CandidateInterventionClass.DISTRIBUTION_TX_OLTC,
         yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.DISTRIBUTION_TX_OLTC,
-        allocationLimitPerYear=50,  # Maximum number of OLTCs to install per year
+        allocationLimitPerYear=999,
         candidateGeneration=CandidateGenerationConfigInput(
-            type=CandidateGenerationType.CRITERIA,  # Required for DISTRIBUTION_TX_OLTC
-            interventionCriteriaName="threshold_set_2",  # References intervention_candidate_criteria.name
+            type=CandidateGenerationType.CRITERIA,
+            interventionCriteriaName="<your-candidate-criteria>",  # intervention_candidate_criteria.name
         ),
-        allocationCriteria="distribution_transformer_oltc_allocation_criteria_1",  # References distribution_transformer_oltc_allocation_criteria.name
-        specificAllocationInstance="distribution_transformer_oltc_instance_1",  # Optional; only 1 instance allowed
+        candidateAllocationCriteria="<your-allocation-criteria>",  # distribution_transformer_oltc_allocation_criteria.name
+        allocationInstanceSelection=["<your-oltc-instance>"],  # distribution_transformer_oltc_instances.name; only 1 allowed
     )
 
-# TARIFF_REFORM
-def build_tariff_reform_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
-        yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.TARIFF_REFORM,  # or InterventionClass.CONTROLLED_LOAD_HOT_WATER
-        allocationCriteria="load_reshape_strategy_1",  # References criteria_name in load_reshape_strategies
+
+# --- Independent interventions: any combination, with or without a candidate ---------------------
+
+def build_load_reshaping() -> LoadReshapingConfigInput:
+    return LoadReshapingConfigInput(
+        loadShapeCriteria="<your-load-reshape-strategy>",  # load_reshape_strategies.criteria_name
     )
 
-# DVMS
-def build_dvms_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
-        yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.DVMS,
-        dvms=DvmsConfigInput(
-            lowerLimit=0.9,             # Minimum acceptable voltage (per unit)
-            upperLimit=1.1,             # Maximum acceptable voltage (per unit)
-            lowerPercentile=5,          # Lower percentile of customer voltages to consider
-            upperPercentile=95,         # Upper percentile of customer voltages to consider
-            maxIterations=3,            # Maximum tap adjustment attempts per time step
-            regulatorConfig=DvmsRegulatorConfigInput(
-                puTarget=1.0,                 # Target voltage (per unit)
-                puDeadbandPercent=12,         # Deadband width as % of target
-                maxTapChangePerStep=2,        # Maximum tap positions to change per iteration
-                allowPushToLimit=True,        # Allow tap changes that improve one side of the voltage distribution even if worsening the other
-            ),
-        ),
-    )
 
-# PHASE_REBALANCING
-def build_phase_rebalancing_intervention() -> InterventionConfigInput:
-    return InterventionConfigInput(
-        baseWorkPackageId=BASE_WORK_PACKAGE_ID,
-        yearRange=YEAR_RANGE,
-        interventionType=InterventionClass.PHASE_REBALANCING,
-        phaseRebalanceProportions=PhaseRebalanceProportionsInput(
-            a=1,  # Target proportions for redistributing single-phase customers across phases.
-            b=1,  # Values do not need to sum to 1 (they are normalized internally), but must
-            c=1,  # all be non-negative. a=b=c=1 gives an even distribution.
+def build_dvms() -> DvmsConfigInput:
+    return DvmsConfigInput(
+        lowerLimit=0.9,
+        upperLimit=1.1,
+        lowerPercentile=5,
+        upperPercentile=95,
+        maxIterations=3,
+        regulatorConfig=DvmsRegulatorConfigInput(
+            puTarget=1.0,
+            puDeadbandPercent=3,
+            maxTapChangePerStep=2,
+            allowPushToLimit=False,
         ),
     )
 
 
-INTERVENTION_BUILDERS = {
-    InterventionClass.COMMUNITY_BESS: build_community_bess_intervention,
-    InterventionClass.LV_STATCOMS: build_lv_statcoms_intervention,
-    InterventionClass.DISTRIBUTION_TAP_OPTIMIZATION: build_distribution_tap_optimization_intervention,
-    InterventionClass.DISTRIBUTION_TX_OLTC: build_distribution_tx_oltc_intervention,
-    InterventionClass.TARIFF_REFORM: build_tariff_reform_intervention,
-    InterventionClass.CONTROLLED_LOAD_HOT_WATER: build_tariff_reform_intervention,
-    InterventionClass.DVMS: build_dvms_intervention,
-    InterventionClass.PHASE_REBALANCING: build_phase_rebalancing_intervention,
+def build_phase_rebalancing() -> PhaseRebalanceProportionsInput:
+    # Normalized internally, so a=b=c=1 is an even distribution.
+    return PhaseRebalanceProportionsInput(a=1, b=1, c=1)
+
+
+# --- Assemble the intervention block ------------------------------------------------------------
+
+CANDIDATE_BUILDERS = {
+    CandidateInterventionClass.COMMUNITY_BESS: build_community_bess_candidate,
+    CandidateInterventionClass.LV_STATCOMS: build_lv_statcoms_candidate,
+    CandidateInterventionClass.DISTRIBUTION_TAP_OPTIMIZATION: build_distribution_tap_optimization_candidate,
+    CandidateInterventionClass.DISTRIBUTION_TX_OLTC: build_distribution_tx_oltc_candidate,
 }
+
+
+# Unset blocks are left as None, which disables that intervention.
+def build_intervention() -> InterventionConfigInput:
+    return InterventionConfigInput(
+        parentWorkPackageId=PARENT_WORK_PACKAGE_ID,
+        candidateIntervention=CANDIDATE_BUILDERS[CANDIDATE_INTERVENTION]() if CANDIDATE_INTERVENTION else None,
+        loadReshaping=build_load_reshaping() if ENABLE_LOAD_RESHAPING else None,
+        phaseRebalanceProportions=build_phase_rebalancing() if ENABLE_PHASE_REBALANCING else None,
+        dvms=build_dvms() if ENABLE_DVMS else None,
+    )
 
 
 async def main(argv):
@@ -162,10 +158,8 @@ async def main(argv):
     config = get_config(config_dir)
     eas_client = get_client(config_dir)
 
-    # Forecast Config example set up.
-    # This should match the base work package's configuration (feeders, years, scenarios, load
-    # time period, model parameters, etc.) other than the intervention block itself, so that any
-    # difference in results can only be attributed to the intervention.
+    # Must match the parent work package's config apart from the intervention block, otherwise
+    # result differences can't be attributed to the intervention.
     forecast_config = ForecastConfigInput(
         feeders=config["feeders"],
         years=config["forecast_years"],
@@ -176,7 +170,7 @@ async def main(argv):
         )
     )
 
-    intervention_config = INTERVENTION_BUILDERS[INTERVENTION_TYPE]()
+    intervention_config = build_intervention()
 
     try:
         result = await eas_client.mutation(Mutation.run_work_package(
@@ -197,12 +191,11 @@ async def main(argv):
                         maxGenTxRatio=10.0,
                         fixOverloadingConsumers=True,
                         fixUndersizedServiceLines=True,
-                        # Must be ADDITIVE (the default) - candidate-based interventions will fail to build otherwise.
+                        # Candidate interventions will fail to build unless this is ADDITIVE (the default).
                         feederScenarioAllocationStrategy=HcFeederScenarioAllocationStrategy.ADDITIVE,
                         closedLoopVRegEnabled=False,
                         seed=123,
-                        # Measurement zones must be set at the distribution transformer level for
-                        # candidate-based interventions and NOT set at the Switch / LV feeder level.
+                        # Candidate interventions need distTransformers zones, not Switch / LV feeder.
                         meterPlacementConfig=HcMeterPlacementConfigInput(
                             feederHead=True,
                             distTransformers=True,

--- a/run_intrinsic_work_package.py
+++ b/run_intrinsic_work_package.py
@@ -1,8 +1,9 @@
 """
-This script provides an example of how to run an Intrinsic Hosting Capacity work package.
+Example: run an Intrinsic Hosting Capacity work package.
 
-Intrinsic mode inverts the standard hosting capacity question: instead of testing a specific DER scenario,
-it finds how much additional load or generation the network can support before hitting a voltage or thermal limit.
+Finds how much load/generation the network can support before hitting a voltage/thermal limit,
+instead of testing a specific DER scenario. Full field reference: HCM docs, "How to run a
+Hosting Capacity Work Package".
 """
 
 import asyncio
@@ -11,8 +12,12 @@ from datetime import datetime
 from zepben.eas import Mutation, IntrinsicWorkPackageInput, IntrinsicSyfConfigInput, \
     IntrinsicSearchConfigInput, IntrinsicInitialLoadStateConfigInput, \
     IntrinsicInitialStateSelectorMode, IntrinsicConstraintsConfigInput, \
-    IntrinsicVoltageConstraintsInput, IntrinsicLvVoltageConstraintInput, \
-    IntrinsicInjectionResourceConfigInput, IntrinsicInjectionResourceMethod, IntrinsicLoadModelType
+    IntrinsicVoltageConstraintsInput, IntrinsicLvVoltageConstraintInput, IntrinsicHvVoltageConstraintInput, \
+    IntrinsicThermalConstraintsInput, IntrinsicThermalConstraintInput, IntrinsicRatingBasis, \
+    IntrinsicInjectionResourceConfigInput, IntrinsicInjectionResourceMethod, IntrinsicLoadModelType, \
+    IntrinsicPhaseMatching, IntrinsicAllocationConfigInput, IntrinsicAllocationMethod, \
+    IntrinsicAllocationScope, IntrinsicExistingCapacityBasis, IntrinsicCapacityGroupPlacementType, \
+    IntrinsicWriterConfigInput, HcWriterType, HcModelConfigInput, HcSolveConfigInput
 
 from utils import get_client, get_config, print_run, get_config_dir
 
@@ -30,45 +35,47 @@ async def main(argv):
                     scenario="base",
                     year=config["forecast_years"][0]
                 ),
-                # Initial state determines the baseline before generation is added.
-                # ZERO_LOAD: empty network - theoretical upper bound, no existing load or DER.
-                # FIXED_TIME: snapshot at a specific timestamp - requires start_time only.
-                # PEAK_FEEDER_EXPORT: worst-case solar moment in a window - most conservative for solar HC.
-                # PEAK_FEEDER_IMPORT: worst-case load moment - most conservative for EV/load growth.
-                # FIXED_LOAD: uniform per-customer baseline - useful for standardised cross-feeder comparisons.
+                # Baseline before generation is added - see docs "Choosing the Initial State" for
+                # mode comparison.
                 initial_state_selector=IntrinsicInitialLoadStateConfigInput(
                     selector_mode=IntrinsicInitialStateSelectorMode.ZERO_LOAD,
                     start_time=datetime.fromisoformat(config["load_time"]["start1"]),
+                    # end_time=...,  # required for PEAK_FEEDER_EXPORT/PEAK_FEEDER_IMPORT
+                    # include_loads=True, include_existing_der=True,          # FIXED_TIME/PEAK_FEEDER_EXPORT/PEAK_FEEDER_IMPORT only
+                    # load_scaling_factor=1.0, der_scaling_factor=1.0,        # FIXED_TIME/PEAK_FEEDER_EXPORT/PEAK_FEEDER_IMPORT only
+                    # per_customer_load_watts=500.0, per_customer_gen_watts=0.0,  # FIXED_LOAD only, required
+                    # per_customer_load_var=0.0, per_customer_gen_var=0.0,        # FIXED_LOAD only, required
                 ),
-                # LV voltage limits in volts (phase-to-neutral).
-                # Values here are emergency limits (VH2=260, VL2=207) - use normal limits (VH1=253, VL1=216)
-                # for a more conservative assessment. Adjust to match your network standard.
-                # Add hv= block to IntrinsicVoltageConstraintsInput to also enforce HV voltage limits (in per unit).
-                # Add thermal= block to IntrinsicConstraintsConfigInput to enforce thermal limits.
+                # LV voltage limits, volts phase-to-neutral. Adjust to your network standard.
+                # A supplied hv=/thermal= block enables that constraint - see docs "Constraints Config".
                 constraints=IntrinsicConstraintsConfigInput(
                     voltage=IntrinsicVoltageConstraintsInput(
-                        lv=IntrinsicLvVoltageConstraintInput(
-                            max=260,
-                            min=207
-                        )
-                    )
+                        lv=IntrinsicLvVoltageConstraintInput(max=260, min=207),
+                        hv=IntrinsicHvVoltageConstraintInput(min_pu=0.90, max_pu=1.10),
+                    ),
+                    thermal=IntrinsicThermalConstraintsInput(
+                        lv=IntrinsicThermalConstraintInput(percent_of_rating=100.0, rating_basis=IntrinsicRatingBasis.NORMAL),
+                        hv=IntrinsicThermalConstraintInput(percent_of_rating=100.0, rating_basis=IntrinsicRatingBasis.NORMAL),
+                    ),
                 ),
-                # EXPORT_GENERATION: find how much solar/generation the network can absorb.
-                # Change to IMPORT_LOAD to find import headroom (e.g. for EV charging or load growth).
+                # EXPORT_GENERATION: solar/gen headroom. IMPORT_LOAD: import headroom (EV/load growth).
                 injection_resource=IntrinsicInjectionResourceConfigInput(
                     method=IntrinsicInjectionResourceMethod.EXPORT_GENERATION,
                     load_model_type=IntrinsicLoadModelType.NEGATIVE_LOAD,
                     power_factor=0.95
+                    # phase_matching=...,  # only MATCH_CUSTOMER_PHASES exposed currently
+                    # pv_profile_id="some-pv-profile-id",  # required when load_model_type is PV_SYSTEM
                 ),
-                # step_kw_per_customer controls precision: smaller = finer results but more iterations.
-                # If headroom equals step_kw_per_customer * max_steps the search hit the limit without
-                # finding a constraint; increase max_steps or step size to find the true upper bound.
+                # headroom == step_kw_per_customer * max_steps means search hit the cap, not a real
+                # constraint - raise max_steps (<=10000) or step size.
                 search=IntrinsicSearchConfigInput(
                     step_kw_per_customer=1.0,
                     max_steps=200,
                     lock_out_capacity_zone_on_violation=True,
                     stop_on_hv_violation=True
-                )
+                ),
+
+                # for the solve, model and results_writer configs, see run_forecast_work_package.py, and you can copy paste it directly in here.
             ),
             config["work_package_name"]
         ))


### PR DESCRIPTION
# Description

Update the Intrinsic Hosting Capacity Examples (LV Hosting Capacity and Node Headroom) and updated the Intervention runner to use the latest EAS (2.18.0b1) to support stacking



